### PR TITLE
Added 'username' attribute to 'livestream' and 'author' classes

### DIFF
--- a/kick/livestream.py
+++ b/kick/livestream.py
@@ -107,6 +107,14 @@ class Livestream(HTTPDataclass["LivestreamPayload"]):
         return self._data["slug"]
 
     @property
+    def username(self) -> str:
+        """
+        The streamer's username
+        """
+
+        return self._data["username"]
+
+    @property
     def channel_id(self) -> int:
         """
         probably the streamer's id or the chatroom id

--- a/kick/livestream.py
+++ b/kick/livestream.py
@@ -62,6 +62,8 @@ class Livestream(HTTPDataclass["LivestreamPayload"]):
         probably the livestream's id
     slug: str
         The streamer's slug
+    username: str
+        The streamer's username
     channel_id: int
         probably the streamer's id or the chatroom id
     created_at: datetime.datetime

--- a/kick/message.py
+++ b/kick/message.py
@@ -24,6 +24,8 @@ class Author(HTTPDataclass["AuthorPayload"]):
         The author's id
     slug: str
         The author's slug
+    username: str
+        The author's username
     color: str
         The authors... color?
     badges: list

--- a/kick/message.py
+++ b/kick/message.py
@@ -45,6 +45,14 @@ class Author(HTTPDataclass["AuthorPayload"]):
         """
 
         return self._data["slug"]
+    
+    @property
+    def username(self) -> str:
+        """
+        The author's username
+        """
+
+        return self._data["username"]
 
     @property
     def color(self) -> str:


### PR DESCRIPTION
Quality of life change for quickly pulling the actual username of a user.

For instance, in the use case of chat logging:
```py
async def log_chat_message(msg):
    author = await msg.author.to_user()
    payload = {
        'sent_at': get_timestamp(),
        'author': author.username,
        'author_id': author.id,
        'content': msg.content,
        'message_id': msg.id,
    }
    
    client.table(CHAT_TABLE).insert(payload).execute()
```
There is no longer a need for the `to_user()` coroutine, as the author's username has now already been passed with `msg.author`

Another example:
```py
async def run(client, msg, args):
    author = await msg.author.to_user()
    await msg.chatroom.send(f"@{author.username} Your balance is {await fetch_user_balance(kick_id=msg.author.id)} coins.")
```
In commands, you can omit the `to_user()` coroutine when quickly replying to a message. Performing `.replace('-', '_')` on `msg.author.slug` is also not preferred for the sake of prettier and more accurate user-facing usernames.

