### PR TITLE
feat: Add reply functionality to chatroom and update HTTP client for …

### DIFF
--- a/kick/chatroom.py
+++ b/kick/chatroom.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from .types.chatroom import BanEntryPayload
     from .types.user import ChatroomPayload
     from .users import User
-    from .message import ReplyMetaData
 
 __all__ = ("Chatroom", "BanEntry", "PartialChatroom")
 
@@ -185,33 +184,6 @@ class PartialChatroom:
         """
 
         await self.http.send_message(self.id, content)
-
-    async def reply(self, content: str, /, metadata: ReplyMetaData, type: str="reply") -> None:
-        """
-        |coro|
-
-        Reply to a message in the chatroom
-
-        Parameters
-        -----------
-        content: str
-            The message's content
-        metadata: 
-            Metadata of the message we are replying to
-        type: 
-            Type of message
-
-        Raises
-        -----------
-        NotFound
-            Streamer or chatter not found
-        HTTPException
-            Sending the message failed
-        Forbidden
-            You are unauthorized from sending the message
-        """
-
-        await self.http.send_message(self.id, content, metadata, type)
 
     async def fetch_chatter(self, chatter_name: str, /) -> Chatter:
         """

--- a/kick/chatroom.py
+++ b/kick/chatroom.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, AsyncIterator, Optional
 
-from kick.http import HTTPClient
-from kick.message import Message
+from .http import HTTPClient
+from .message import Message
 
 from .emotes import Emote
 from .enums import ChatroomChatMode
@@ -189,7 +189,7 @@ class PartialChatroom:
             The message
         """
         data = await self.http.send_message(self.id, content)
-        message = Message(data=data, http=self.http)
+        message = Message(data=data.data, http=self.http)
         return message
 
     async def fetch_chatter(self, chatter_name: str, /) -> Chatter:
@@ -219,7 +219,7 @@ class PartialChatroom:
         from .chatter import Chatter
 
         data = await self.http.get_chatter(self.streamer_name, chatter_name)
-        chatter = Chatter(data=data, http=self.http, chatroom=self)
+        chatter = Chatter(data=data["data"], http=self.http, chatroom=self)
         return chatter
 
     async def fetch_rules(self) -> str:

--- a/kick/chatroom.py
+++ b/kick/chatroom.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from .types.chatroom import BanEntryPayload
     from .types.user import ChatroomPayload
     from .users import User
+    from .message import ReplyMetaData
 
 __all__ = ("Chatroom", "BanEntry", "PartialChatroom")
 
@@ -184,6 +185,33 @@ class PartialChatroom:
         """
 
         await self.http.send_message(self.id, content)
+
+    async def reply(self, content: str, /, metadata: ReplyMetaData, type: str="reply") -> None:
+        """
+        |coro|
+
+        Reply to a message in the chatroom
+
+        Parameters
+        -----------
+        content: str
+            The message's content
+        metadata: 
+            Metadata of the message we are replying to
+        type: 
+            Type of message
+
+        Raises
+        -----------
+        NotFound
+            Streamer or chatter not found
+        HTTPException
+            Sending the message failed
+        Forbidden
+            You are unauthorized from sending the message
+        """
+
+        await self.http.send_message(self.id, content, metadata, type)
 
     async def fetch_chatter(self, chatter_name: str, /) -> Chatter:
         """

--- a/kick/chatroom.py
+++ b/kick/chatroom.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, AsyncIterator, Optional
 
 from kick.http import HTTPClient
+from kick.message import Message
 
 from .emotes import Emote
 from .enums import ChatroomChatMode
@@ -162,7 +163,7 @@ class PartialChatroom:
         await self.http.ws.unsubscribe_to_chatroom(self.id)
         self.http.client._chatrooms.pop(self.id)
 
-    async def send(self, content: str, /) -> None:
+    async def send(self, content: str, /) -> Message:
         """
         |coro|
 
@@ -181,9 +182,15 @@ class PartialChatroom:
             Sending the message failed
         Forbidden
             You are unauthorized from sending the message
-        """
 
-        await self.http.send_message(self.id, content)
+        Returns
+        -----------
+        Message
+            The message
+        """
+        data = await self.http.send_message(self.id, content)
+        message = Message(data=data, http=self.http)
+        return message
 
     async def fetch_chatter(self, chatter_name: str, /) -> Chatter:
         """

--- a/kick/chatroom.py
+++ b/kick/chatroom.py
@@ -189,7 +189,7 @@ class PartialChatroom:
             The message
         """
         data = await self.http.send_message(self.id, content)
-        message = Message(data=data.data, http=self.http)
+        message = Message(data=data["data"], http=self.http)
         return message
 
     async def fetch_chatter(self, chatter_name: str, /) -> Chatter:

--- a/kick/http.py
+++ b/kick/http.py
@@ -337,10 +337,10 @@ class HTTPClient:
         raise RuntimeError("Unreachable situation occured in http handling")
 
     def send_message(
-        self, chatroom: int, content: str, metadata: None | dict, type: str
+        self, chatroom: int, content: str, metadata: None | dict = None, msg_type: str = "message"
     ) -> Response[V2MessageSentPayload]:
         route = Route.root("POST", f"/api/v2/messages/send/{chatroom}")
-        data = {"content": content, "type": type}
+        data = {"content": content, "type": msg_type}
         if metadata is not None:
             data["metadata"] = metadata
         return self.request(

--- a/kick/message.py
+++ b/kick/message.py
@@ -259,6 +259,30 @@ class Message(HTTPDataclass["MessagePayload"]):
             "original_sender": original_sender,
         }
 
+    async def reply(self, content: str, /) -> None:
+        """
+        |coro|
+
+        Reply to a current message in the chatroom
+
+        Parameters
+        -----------
+        content: str
+            The message's content
+
+        Raises
+        -----------
+        NotFound
+            Streamer or chatter not found
+        HTTPException
+            Sending the message failed
+        Forbidden
+            You are unauthorized from sending the message
+        """
+
+        await self.http.send_message(self.chatroom.id, content, self.reply_metadata)
+
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__) and other.id == self.id
 

--- a/kick/message.py
+++ b/kick/message.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from kick.types.message import BaseMessagePayload
+
 from .object import HTTPDataclass
 from .users import PartialUser, User
 from .utils import cached_property
@@ -259,7 +261,7 @@ class Message(HTTPDataclass["MessagePayload"]):
             "original_sender": original_sender,
         }
 
-    async def reply(self, content: str, /) -> None:
+    async def reply(self, content: str, /) -> Message:
         """
         |coro|
 
@@ -278,9 +280,18 @@ class Message(HTTPDataclass["MessagePayload"]):
             Sending the message failed
         Forbidden
             You are unauthorized from sending the message
-        """
 
-        await self.http.send_message(self.chatroom.id, content, self.reply_metadata)
+        Returns
+        -----------
+        Message
+            The message
+        """
+        data = await self.http.send_message(self.chatroom.id, 
+                                            content, 
+                                            metadata=self.reply_metadata, 
+                                            msg_type="reply")
+        message = Message(data=data, http=self.http)
+        return message
 
 
     def __eq__(self, other: object) -> bool:

--- a/kick/message.py
+++ b/kick/message.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from kick.types.message import BaseMessagePayload
-
 from .object import HTTPDataclass
 from .users import PartialUser, User
 from .utils import cached_property
@@ -290,7 +288,7 @@ class Message(HTTPDataclass["MessagePayload"]):
                                             content, 
                                             metadata=self.reply_metadata, 
                                             msg_type="reply")
-        message = Message(data=data, http=self.http)
+        message = Message(data=data["data"], http=self.http)
         return message
 
 

--- a/kick/message.py
+++ b/kick/message.py
@@ -240,6 +240,25 @@ class Message(HTTPDataclass["MessagePayload"]):
 
         return Author(data=self._data["sender"], http=self.http)
 
+    @property
+    def reply_metadata(self) -> ReplyMetaData:
+        """
+        The metadata from message to reply
+        """
+        original_sender = {
+            "id": self.author.id,
+            "username": self.author.username
+        }
+        original_message = {
+            "id": self.id,
+            "content": self.content
+        }
+
+        return {
+            "original_message": original_message,
+            "original_sender": original_sender,
+        }
+
     def __eq__(self, other: object) -> bool:
         return isinstance(other, self.__class__) and other.id == self.id
 

--- a/kick/types/message.py
+++ b/kick/types/message.py
@@ -69,3 +69,8 @@ class FetchMessagesPayload(TypedDict):
 
 class V1MessageSentPayload(StatusPayload):
     ...
+
+
+class V2MessageSentPayload(StatusPayload):
+    status: StatusPayload
+    data: BaseMessagePayload

--- a/kick/types/message.py
+++ b/kick/types/message.py
@@ -67,10 +67,6 @@ class FetchMessagesPayload(TypedDict):
     data: FetchMessagesDataPayload
 
 
-class V1MessageSentPayload(StatusPayload):
-    ...
-
-
 class V2MessageSentPayload(StatusPayload):
     status: StatusPayload
     data: BaseMessagePayload

--- a/kick/ws.py
+++ b/kick/ws.py
@@ -34,7 +34,7 @@ class PusherWebSocket:
 
         match raw_data["event"]:
             case "App\\Events\\ChatMessageEvent":
-                msg = Message(data=data["livestream"], http=self.http)
+                msg = Message(data=data, http=self.http)
                 self.http.client.dispatch("message", msg)
             case "App\\Events\\StreamerIsLive":
                 livestream = PartialLivestream(data=data, http=self.http)


### PR DESCRIPTION
 Refactor message handling and add ReplyMetaData extraction

 - Added `reply_metadata` function to extract `ReplyMetaData` from a `Message`.
 - Updated type definitions in `kick/types/message.py` to ensure consistency.
 - Fixed import issues by correctly importing the `MessagePayload` type.
 - Fixed ws app client id now it looks like 
       `wss://ws-us2.pusher.com/app/32cbd69e4b950bf97679?protocol=7&client=js&version=8.4.0-rc2&flash=false`
…V2 API
  - Also send message now using v2 api and added reply functionality to chat
  - Fix for "App\\Events\\ChatMessageEvent" probably currently it is not using "livestream" key any more

 This commit ensures that reply messages can be properly handled and their metadata extracted for further processing.